### PR TITLE
feat(config): add --config flag with $HOME fallback

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include <filesystem>
 #include <toml.hpp>
 
-int main()
+int main(int argc, char** argv)
 {
 	// Initialize default configuration
 	AppConfig config = {
@@ -21,14 +21,26 @@ int main()
 		}
 	};
 
-	// Two-tier config lookup: user override > deb-installed default
+	// Config lookup: --config <path> (or --config=<path>) overrides everything;
+	// otherwise user override > deb-installed default.
 	const std::string home = getenv("HOME") ? getenv("HOME") : "/tmp";
 	const auto user_config = std::filesystem::path(home) / ".config/ark/rtsp-server/config.toml";
 	const auto default_config = std::filesystem::path("/opt/ark/share/rtsp-server/config.toml");
-	const auto config_path = std::filesystem::exists(user_config) ? user_config : default_config;
+	std::string config_path = (std::filesystem::exists(user_config) ? user_config : default_config).string();
+
+	for (int i = 1; i < argc; i++) {
+		std::string arg = argv[i];
+
+		if (arg == "--config" && i + 1 < argc) {
+			config_path = argv[++i];
+
+		} else if (arg.rfind("--config=", 0) == 0) {
+			config_path = arg.substr(std::string("--config=").size());
+		}
+	}
 
 	try {
-		toml::table tomlConfig = toml::parse_file(config_path.string());
+		toml::table tomlConfig = toml::parse_file(config_path);
 
 		// RTSP server config
 		if (auto rtsp = tomlConfig["rtsp"].as_table()) {


### PR DESCRIPTION
## Summary

Add a `--config <path>` (or `--config=<path>`) argument so the config file can be read from an explicit path, defaulting to the existing `$HOME/.local/share/rtsp-server/config.toml`.

## Problem

The config path was hardcoded to `$HOME/.local/share/rtsp-server/config.toml`. ARK-OS is moving to FHS packaging where the config lives at `/etc/ark-os/rtsp-server.toml` and the service runs as a system user, so the binary, the web UI, and the shipped config must all reference the same file.

## Solution

Parse `--config`/`--config=` from argv and use it for the TOML load, keeping the `$HOME` path as the default so dev-machine behaviour is unchanged.

Part of ARK-Electronics/ARK-OS#68.
