### PR TITLE
fix(config): accept port as TOML integer or string

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,8 +53,18 @@ int main(int argc, char** argv)
 			}
 
 			if (rtsp->contains("port")) {
-				int port = (*rtsp)["port"].value_or(5600);
-				config.server.port = std::to_string(port);
+				// Accept the port whether it is stored as a TOML integer
+				// (port = 5600) or a quoted string (port = "5600"). value_or<int>
+				// silently returns the fallback when the stored type does not
+				// match, so handle both forms explicitly.
+				auto port = (*rtsp)["port"];
+
+				if (auto i = port.value<int64_t>()) {
+					config.server.port = std::to_string(*i);
+
+				} else if (auto s = port.value<std::string>()) {
+					config.server.port = *s;
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
fixes ARK-Electronics/ARK-OS#73

Port values set via the ARK-UI TOML editor were intermittently ignored, with the server binding to the hardcoded `5600` fallback instead of the configured value.

## Problem
`main.cpp` read the port with `value_or(5600)`, which in toml++ only extracts an integer-typed node. The web UI inconsistently writes the field as either an unquoted integer (`port = 3333`) or a quoted string (`port = "3333"`). When stored as a string, the typed `value_or<int>` does not coerce and silently returns the `5600` fallback, so the user-configured port is dropped. The inconsistency in how the value is quoted is what made the bug non-deterministic.

## Solution
Read the port as either a TOML integer or a TOML string before storing it. `config.server.port` is a `std::string` consumed directly by `gst_rtsp_server_set_service`, so both forms map cleanly onto the existing type; any other type keeps the default.
