### PR TITLE
fix(pipeline): pin NV12 format on the Pi libcamerasrc pad

### DIFF
--- a/src/RtspServer.cpp
+++ b/src/RtspServer.cpp
@@ -132,9 +132,12 @@ std::string RtspServer::create_pi_pipeline()
 	// Cap framerate at 30fps
 	int framerate = std::min(_cameraConfig.framerate, 30);
 
-	// Start building the pipeline
+	// Start building the pipeline.
+	// format=NV12 is required: without an explicit format, libcamerasrc negotiates its
+	// src pad to the sensor's RAW Bayer stream (e.g. imx708 -> SBGGR16), which videoconvert
+	// cannot consume -> "not-negotiated". NV12 is the PiSP ISP's native processed output.
 	ss << "( libcamerasrc ! "
-	   << "video/x-raw,width=" << width
+	   << "video/x-raw,format=NV12,width=" << width
 	   << ",height=" << height
 	   << ",framerate=" << framerate << "/1 ! "
 	   << "videoconvert ! ";


### PR DESCRIPTION
## Summary
Relates to #8

Pin `format=NV12` on the `libcamerasrc` caps in the Pi pipeline so the camera negotiates a processed stream instead of RAW Bayer.

## Problem
Without an explicit `format=`, `libcamerasrc` resolves its src pad to the sensor's RAW Bayer stream (imx708 → SBGGR16 2304×1296), which `videoconvert` can't consume. The result is `gst_libcamera_src_negotiate()` → `not-negotiated (-4)`: the RTSP media never prerolls, so QGC shows no video and the client reconnects roughly once a second. This affects the Camera Module 3 / imx708 on Pi 5 / CM5 with libcamera v0.7.1.

## Solution
Add `format=NV12` (the PiSP ISP's native processed output) to the `libcamerasrc` capsfilter in `create_pi_pipeline()`. Verified on hardware (Just-A-Pi CM5 + imx708): the prior caps produce a 0-byte capture, while `format=NV12` yields a 4.25 MB H.264 stream from the same pipeline. NV12 is correct for every libcamera sensor on the Pi ISP, so this is a flat default rather than sensor-specific. The systemic, sensor-aware version is tracked in #8.
